### PR TITLE
Update ViewHelpers\Uri\ImageViewHelper for TYPO3 8.7

### DIFF
--- a/Classes/Xclass/Fluid/ViewHelpers/Uri/ImageViewHelper.php
+++ b/Classes/Xclass/Fluid/ViewHelpers/Uri/ImageViewHelper.php
@@ -26,55 +26,6 @@ class ImageViewHelper extends \TYPO3\CMS\Fluid\ViewHelpers\Uri\ImageViewHelper
 {
 
     /**
-     * Resizes the image (if required) and returns its path. If the image was not resized, the path will be equal to $src
-     *
-     * @see https://docs.typo3.org/typo3cms/TyposcriptReference/ContentObjects/ImgResource/
-     *
-     * @param string                           $src
-     * @param FileInterface|AbstractFileFolder $image
-     * @param string                           $width              width of the image. This can be a numeric value representing the fixed width of the image in pixels. But you can also perform simple calculations by adding "m" or "c" to the value. See imgResource.width for possible options.
-     * @param string                           $height             height of the image. This can be a numeric value representing the fixed height of the image in pixels. But you can also perform simple calculations by adding "m" or "c" to the value. See imgResource.width for possible options.
-     * @param int                              $minWidth           minimum width of the image
-     * @param int                              $minHeight          minimum height of the image
-     * @param int                              $maxWidth           maximum width of the image
-     * @param int                              $maxHeight          maximum height of the image
-     * @param bool                             $treatIdAsReference given src argument is a sys_file_reference record
-     * @param string|bool                      $crop               overrule cropping of image (setting to FALSE disables the cropping set in FileReference)
-     * @param bool                             $absolute           Force absolute URL
-     *
-     * @return string
-     * @throws Exception
-     * @throws \Exception
-     */
-    public function render(
-        $src = null,
-        $image = null,
-        $width = null,
-        $height = null,
-        $minWidth = null,
-        $minHeight = null,
-        $maxWidth = null,
-        $maxHeight = null,
-        $treatIdAsReference = false,
-        $crop = null,
-        $absolute = false
-    ) {
-        return self::renderStatic([
-            'src'                => $src,
-            'image'              => $image,
-            'width'              => $width,
-            'height'             => $height,
-            'minWidth'           => $minWidth,
-            'minHeight'          => $minHeight,
-            'maxWidth'           => $maxWidth,
-            'maxHeight'          => $maxHeight,
-            'treatIdAsReference' => $treatIdAsReference,
-            'crop'               => $crop,
-            'absolute'           => $absolute,
-        ], $this->buildRenderChildrenClosure(), $this->renderingContext);
-    }
-
-    /**
      * @param array                     $arguments
      * @param callable|\Closure         $renderChildrenClosure
      * @param RenderingContextInterface $renderingContext


### PR DESCRIPTION
The class `ViewHelpers\Uri\ImageViewHelper` still contained incompatible code, similar to the code which was removed in #21 for another `ViewHelpers\ImageViewHelper`